### PR TITLE
Fixed ros source error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -69,7 +69,7 @@ if ! grep -Fxq "$ROS_SOURCE_LINE" ~/.bashrc; then
     echo "$ROS_SOURCE_LINE" >> ~/.bashrc
     echo "Added ROS2 sourcing to ~/.bashrc"
 fi
-source /opt/ros/humble/setup.bash
+source /opt/ros/${ROSDISTRO_DETECTED}/setup.bash
 
 cd "$DIR"
 


### PR DESCRIPTION
This line sourced ros humble, when it should be using ${ROSDISTRO_DETECTED} instead